### PR TITLE
Update upload globs to callout JRE

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,30 +20,36 @@ jobs:
   release-github:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      - uses: actions/checkout@v2
       - name: Download Artifacts
         uses: actions/download-artifact@v2
       - name: Create GitHub Release
-        run: gh release create "${GITHUB_REF#refs/tags/}" **/*
+        if: github.repository_owner == 'wpilibsuite' && startsWith(github.ref, 'refs/tags/v')
+        run: gh release create "${GITHUB_REF#refs/tags/}" JRE/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-artifactory:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2
       - uses: jfrog/setup-jfrog-cli@v2
+        if: github.repository_owner == 'wpilibsuite' && startsWith(github.ref, 'refs/tags/v')
         env:
           JF_ARTIFACTORY_1: ${{ secrets.ARTIFACTORY_CLI_SECRET }}
       - name: Download Artifacts
         uses: actions/download-artifact@v2
-      - name: Upload
+      - name: Generate Maven
         run: |
           source versions.sh
-          mvn install:install-file -DlocalRepositoryPath=mvn -Dfile=${IPK_NAME} -DgroupId=edu.wpi.first.jdk -DartifactId=roborio-${YEAR} -Dversion=${VER} -Dpackaging=ipk -DgeneratePom=true
-
-          cd mvn
-          jfrog rt u "*" thirdparty-mvn-release/ --exclusions="*maven-metadata-local*"
+          mvn install:install-file -DlocalRepositoryPath=mvn -Dfile=JRE/${IPK_NAME} -DgroupId=edu.wpi.first.jdk -DartifactId=roborio-${YEAR} -Dversion=${VER} -Dpackaging=ipk -DgeneratePom=true
+      - name: Upload
+        if: github.repository_owner == 'wpilibsuite' && startsWith(github.ref, 'refs/tags/v')
+        working-directory: mvn
+        run: jfrog rt u "*" thirdparty-mvn-release/ --exclusions="*maven-metadata-local*"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Maven
+          path: mvn


### PR DESCRIPTION
The default behavior of the download-artifact action is to place each artifact in a named directory in the current working dir when no parameters are provided. This updates the consuming actions to match this assumption.

We also need to checkout the repo in order to use the GitHub CLI.