### PR TITLE
Disable mallinfo, send SIGKILL on abort

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ wget -nc https://github.com/openjdk/jdk17u/archive/refs/tags/${GIT_TAG}.tar.gz
 tar xzf ${GIT_TAG}.tar.gz
 pushd jdk17u-`echo ${GIT_TAG} | sed -e s/+/-/`
 patch -p0 < ../config.guess.patch
+patch -p1 < ../kill_on_abort.patch
 patch -p1 < ../disable_mallinfo.patch
 bash configure \
 	--openjdk-target=arm-frc${YEAR}-linux-gnueabi \

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ wget -nc https://github.com/openjdk/jdk17u/archive/refs/tags/${GIT_TAG}.tar.gz
 tar xzf ${GIT_TAG}.tar.gz
 pushd jdk17u-`echo ${GIT_TAG} | sed -e s/+/-/`
 patch -p0 < ../config.guess.patch
+patch -p1 < ../disable_mallinfo.patch
 bash configure \
 	--openjdk-target=arm-frc${YEAR}-linux-gnueabi \
 	--with-abi-profile=arm-vfp-sflt \

--- a/control
+++ b/control
@@ -1,5 +1,5 @@
 Package: frc2024-openjdk-17-jre
-Version: 17.0.9u7-1
+Version: 17.0.9u7-2
 Description: FRC OpenJDK Java Runtime Environment
 Section: devel
 Priority: optional

--- a/disable_mallinfo.patch
+++ b/disable_mallinfo.patch
@@ -1,0 +1,13 @@
+diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
+index a14942752b2..a8b6679cfc0 100644
+--- a/src/hotspot/os/linux/os_linux.cpp
++++ b/src/hotspot/os/linux/os_linux.cpp
+@@ -2293,7 +2293,7 @@ void os::Linux::print_process_memory_info(outputStream* st) {
+   // glibc only:
+   // - Print outstanding allocations using mallinfo
+   // - Print glibc tunables
+-#ifdef __GLIBC__
++#if 0
+   size_t total_allocated = 0;
+   size_t free_retained = 0;
+   bool might_have_wrapped = false;

--- a/kill_on_abort.patch
+++ b/kill_on_abort.patch
@@ -1,0 +1,13 @@
+diff --git a/src/hotspot/os/posix/os_posix.cpp b/src/hotspot/os/posix/os_posix.cpp
+index fd94f40282c..b6ca6e5d0b6 100644
+--- a/src/hotspot/os/posix/os_posix.cpp
++++ b/src/hotspot/os/posix/os_posix.cpp
+@@ -2081,7 +2081,7 @@ void os::abort(bool dump_core, void* siginfo, const void* context) {
+     LINUX_ONLY(if (DumpPrivateMappingsInCore) ClassLoader::close_jrt_image();)
+     ::abort(); // dump core
+   }
+-  ::_exit(1);
++  os::signal_raise(SIGKILL);
+ }
+ 
+ // Die immediately, no exit hook, no abort hook, no cleanup.


### PR DESCRIPTION
These improve the probability of the JVM exiting instead of hanging on exit.